### PR TITLE
[REJECTED] Network Monitor: Runtime selection of DHCP/Static IP with fall back set by fsutil/ipcfg and a polled mode for HW lacking a PHY interrupt

### DIFF
--- a/examples/ipcfg/Kconfig
+++ b/examples/ipcfg/Kconfig
@@ -1,0 +1,30 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config EXAMPLES_IPCFG
+	tristate "IPv4 Configuration file example"
+	default n
+	select FS_TMPFS
+	---help---
+		Enable the IPv4 Configuration file example
+
+if EXAMPLES_IPCFG
+
+config EXAMPLES_IPCFG_PROGNAME
+	string "IPCFG Program name"
+	default "ipcfg"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config EXAMPLES_IPCFG_PRIORITY
+	int "IPCFG task priority"
+	default 100
+
+config EXAMPLES_IPCFG_STACKSIZE
+	int "IPCFG stack size"
+	default DEFAULT_TASK_STACKSIZE
+
+endif

--- a/examples/ipcfg/Make.defs
+++ b/examples/ipcfg/Make.defs
@@ -1,0 +1,24 @@
+############################################################################
+# apps/examples/ipcfg/Make.defs
+# Adds selected applications to apps/ build
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_EXAMPLES_IPCFG),)
+CONFIGURED_APPS += $(APPDIR)/examples/ipcfg
+endif

--- a/examples/ipcfg/Makefile
+++ b/examples/ipcfg/Makefile
@@ -1,0 +1,34 @@
+############################################################################
+# apps/examples/ipcfg/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# IPv4 Configuration file example built-in application info
+
+PROGNAME  = $(CONFIG_EXAMPLES_IPCFG_PROGNAME)
+PRIORITY  = $(CONFIG_EXAMPLES_IPCFG_PRIORITY)
+STACKSIZE = $(CONFIG_EXAMPLES_IPCFG_STACKSIZE)
+MODULE    = $(CONFIG_EXAMPLES_IPCFG)
+
+# Pv4 Configuration file example
+
+MAINSRC = ipcfg_main.c
+
+include $(APPDIR)/Application.mk

--- a/examples/ipcfg/ipcfg_main.c
+++ b/examples/ipcfg/ipcfg_main.c
@@ -1,0 +1,196 @@
+/****************************************************************************
+ * examples/ipcfg/ipcfg_main.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/mount.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <arpa/inet.h>
+
+#include "fsutils/ipcfg.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_IPCFG_CHARDEV
+#  error This example will not work with a character device
+#endif
+
+#ifndef CONFIG_IPCFG_WRITABLE
+#  warning This example will not work with a without write support
+#endif
+
+#define DEVICE1       "eth0"
+#define DEVICE2       "eth1"
+#define IPv4PROTO_MAX IPv4PROTO_FALLBACK
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const char *g_ipv4proto_name[] =
+{
+  "none",      /* IPv4PROTO_NONE */
+  "static",    /* IPv4PROTO_STATIC */
+  "dhcp",      /* IPv4PROTO_DHCP */
+  "fallback"   /* IPv4PROTO_FALLBACK */
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ipcfg_dump_addr
+ ****************************************************************************/
+
+static void ipcfg_dump_addr(FAR const char *variable, in_addr_t address)
+{
+  if (address == 0)
+    {
+      printf("%s[UNSPECIFIED]\n", variable);
+    }
+  else
+    {
+      struct in_addr saddr =
+      {
+        address
+      };
+
+      printf("%s%s\n", variable, inet_ntoa(saddr));
+    }
+}
+
+/****************************************************************************
+ * Name: ipcfg_dump_config
+ ****************************************************************************/
+
+static int ipcfg_dump_config(FAR const char *netdev)
+{
+  struct ipv4cfg_s ipv4cfg;
+  int ret;
+
+  ret = ipcfg_read(netdev, (FAR struct ipcfg_s *)&ipv4cfg, AF_INET);
+  if (ret < 0)
+    {
+      fprintf(stderr, "ERROR: ipcfg_read() failed: %d\n", ret);
+      return ret;
+    }
+
+  /* Dump the content in human readable form */
+
+  printf("%s:\n", netdev);
+
+  if (ipv4cfg.proto > IPv4PROTO_MAX)
+    {
+      printf("BOOTPROTO: %d [INVALID]\n", ipv4cfg.proto);
+    }
+  else
+    {
+      printf("BOOTPROTO: %s\n", g_ipv4proto_name[ipv4cfg.proto]);
+    }
+
+  ipcfg_dump_addr("IPADDR:     ",  ipv4cfg.ipaddr);
+  ipcfg_dump_addr("NETMASK:    ",  ipv4cfg.netmask);
+  ipcfg_dump_addr("ROUTER:     ",  ipv4cfg.router);
+  ipcfg_dump_addr("DNS:        ",  ipv4cfg.dnsaddr);
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: ipcfg_write_config
+ ****************************************************************************/
+
+static int ipcfg_write_config(FAR const char *netdev)
+{
+  struct ipv4cfg_s ipv4cfg;
+  int ret;
+
+  ipv4cfg.proto   = IPv4PROTO_DHCP;
+  ipv4cfg.ipaddr  = HTONL(0x0a000002);
+  ipv4cfg.netmask = HTONL(0xffffff00);
+  ipv4cfg.router  = HTONL(0x0a000001);
+  ipv4cfg.dnsaddr = HTONL(0x0a000003);
+
+  ret = ipcfg_write(netdev, (FAR struct ipcfg_s *)&ipv4cfg, AF_INET);
+  if (ret < 0)
+    {
+      fprintf(stderr, "ERROR: ipcfg_write() ipcfg_write: %d\n", ret);
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ipcfg_main
+ ****************************************************************************/
+
+int main(int argc, FAR char *argv[])
+{
+  int ret;
+
+  /* Mount the TMPFS file system at the expected location for the IPv4
+   * Configuration file directory.
+   */
+
+  ret = mount(NULL, CONFIG_IPCFG_PATH, "tmpfs", 0, NULL);
+  if (ret < 0)
+    {
+      int errcode = errno;
+      fprintf(stderr, "ERROR: Failed to open " CONFIG_IPCFG_PATH "\n: %d",
+              errcode);
+      return EXIT_FAILURE;
+    }
+
+  /* Dump files.  These should all fail. */
+
+  printf("\n1. Dump before creating configuration files\n\n");
+  ipcfg_dump_config(DEVICE1);
+  ipcfg_dump_config(DEVICE2);
+
+#ifdef CONFIG_IPCFG_WRITABLE
+  /* Create files */
+
+  printf("\n2. Create configuration files\n\n");
+  ipcfg_write_config(DEVICE1);
+  ipcfg_write_config(DEVICE2);
+
+  /* Dump the files again */
+
+  printf("\n3. Dump after creating configuration files\n\n");
+  ipcfg_dump_config(DEVICE1);
+  ipcfg_dump_config(DEVICE2);
+#endif
+
+  umount(CONFIG_IPCFG_PATH);
+  return EXIT_SUCCESS;
+}

--- a/fsutils/ipcfg/Kconfig
+++ b/fsutils/ipcfg/Kconfig
@@ -1,0 +1,71 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config FSUTILS_IPCFG
+	bool "IPv4 Configuration File Support"
+	default n
+	depends on NET_IPv4
+	---help---
+		Enables support for an IPv4 configuration file that holds IP
+		address and/or DHCP configuration information for a
+		specific network device
+
+		There is no dependency on IPv4 networking support so this
+		configuration may be used in testing without a network.
+
+if FSUTILS_IPCFG
+
+config IPCFG_WRITABLE
+	bool "Writable IPv4 Configuration"
+	default y
+	---help---
+		Can be used to disable writing to the IPv4 Configuration file.  This
+		would be necessary if, for example, the IPv4 Configuration file were
+		provided on a read-only file system.
+
+config IPCFG_BINARY
+	bool "Binary IPv4 Configuration File"
+	default n
+	---help---
+		By default, the IPv4 configuration file is an ASCII human readable
+		file with <varialble>=<value> pairs.  A Binary interface may be used
+		for more constrained media such as EEPROM.
+
+config IPCFG_PATH
+	string "IPv4 Configuration File Directory"
+	default "/etc/sysconfig/network-scripts"
+	---help---
+		Specifies the full path to the directory or mountpoint that holds
+		the IPv4 Configuration files.  Each individual configuration file
+		within this directory will have names like ipcfg-eth0.
+
+		If CONFIG_IPCFG_CHARDEV is select, this setting is interpreted
+		differently.  In this case, CONFIG_IPCFG_PATH is the full path
+		to the character driver.
+
+config IPCFG_CHARDEV
+	bool "Character Driver"
+	default n
+	depends on IPCFG_BINARY
+	---help---
+		In some use cases, where there is only a single network device and
+		only a single network device, a character driver on, perhaps, EEPROM
+		may be used.  In this case there is not file system and the
+		CONFIG_IPCFG_PATH will refer to that character driver.
+
+		NOTE that this configuration is only support with CONFIG_IPCFG_BINARY.
+
+config IPCFG_OFFSET
+	int "Data offset"
+	default 0
+	depends on IPCFG_CHARDEV
+	---help---
+		Seek to this offset before reading or writing the IPv4 Configuration.
+		This is only support for the character driver device.  This permits
+		some formatting of, say, EEPROM, so that multiple, different
+		configurations can be maintained at differnt offsets into the IPv4
+		Configuration File.
+
+endif # FSUTILS_IPCFG

--- a/fsutils/ipcfg/Make.defs
+++ b/fsutils/ipcfg/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# apps/fsutils/ipcfg/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifeq ($(CONFIG_FSUTILS_IPCFG),y)
+CONFIGURED_APPS += $(APPDIR)/fsutils/ipcfg
+endif

--- a/fsutils/ipcfg/Makefile
+++ b/fsutils/ipcfg/Makefile
@@ -1,0 +1,29 @@
+############################################################################
+# apps/fsutils/ipcfg/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+# IPv4 Configuration file access library
+
+ifeq ($(CONFIG_FSUTILS_IPCFG),y)
+CSRCS += ipcfg.c
+endif
+
+include $(APPDIR)/Application.mk

--- a/fsutils/ipcfg/ipcfg.c
+++ b/fsutils/ipcfg/ipcfg.c
@@ -1,0 +1,650 @@
+/****************************************************************************
+ * apps/fsutils/ipcfg/ipcfg.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <ctype.h>
+
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include "fsutils/ipcfg.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define MAX_LINESIZE  80
+#define MAX_IPv4PROTO IPv4PROTO_FALLBACK
+
+/* Values for the record type field */
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* IP Configuration record header. */
+
+struct ipcfg_header_s
+{
+  uint8_t next;         /* Offset to the next IP configuration record */
+  sa_family_t type;     /* Must be AF_INET */
+};
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_IPCFG_WRITABLE) && !defined(CONFIG_IPCFG_BINARY)
+static const char *g_ipv4proto_name[] =
+{
+  "none",      /* IPv4PROTO_NONE */
+  "static",    /* IPv4PROTO_STATIC */
+  "dhcp",      /* IPv4PROTO_DHCP */
+  "fallback"   /* IPv4PROTO_FALLBACK */
+};
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ipcfg_allocpath
+ *
+ * Description:
+ *   Allocate memory for and construct the full path to the IPv4
+ *   Configuration file.
+ *
+ * Input Parameters:
+ *   netdev - The network device.  For examplel "eth0"
+ *
+ * Returned Value:
+ *   A pointer to the allocated path is returned.  NULL is returned only on
+ *  on a failure to allocate.
+ *
+ ****************************************************************************/
+
+static inline FAR char *ipcfg_allocpath(FAR const char *netdev)
+{
+#ifndef CONFIG_IPCFG_CHARDEV
+  FAR char *path = NULL;
+  int ret;
+
+  /* Create the full path to the ipcfg file for the network device.
+   * the path of CONFIG_IPCFG_PATH returns to a directory containing
+   * multiple files of the form ipcfg-<dev> where <dev> is the network
+   * device name.  For example, ipcfg-eth0.
+   */
+
+  ret = asprintf(&path, CONFIG_IPCFG_PATH "/ipcfg-%s", netdev);
+  if (ret < 0 || path == NULL)
+    {
+      /* Assume that asprintf failed to allocate memory */
+
+      fprintf(stderr, "ERROR: Failed to create path to ipcfg file: %d\n",
+              ret);
+      return NULL;
+    }
+
+  return path;
+
+#else
+  /* In this case CONFIG_IPCFG_PATH is the full path to a character device
+   * that describes the configuration of a single network device.
+   *
+   * It is dup'ed to simplify typing (const vs non-const) and to make the
+   * free operation unconditional.
+   */
+
+  return strdup(CONFIG_IPCFG_PATH);
+#endif
+}
+
+/****************************************************************************
+ * Name: ipcfg_open (for ASCII mode)
+ *
+ * Description:
+ *   Form the complete path to the ipcfg file and open it.
+ *
+ * Input Parameters:
+ *   netdev - The network device.  For examplel "eth0"
+ *   stream - Location to return the opened stream
+ *   mode   - File fopen mode
+ *
+ * Returned Value:
+ *   Zero is returned on success; a negated errno value is returned on any
+ *   failure.
+ *
+ ****************************************************************************/
+
+#ifndef CONFIG_IPCFG_BINARY
+static int ipcfg_open(FAR const char *netdev, FAR FILE **stream,
+                      FAR const char *mode)
+{
+  FAR char *path;
+  int ret;
+
+  /* Create the full path to the ipcfg file for the network device */
+
+  path = ipcfg_allocpath(netdev);
+  if (path == NULL)
+    {
+      /* Assume failure to allocate memory */
+
+      fprintf(stderr, "ERROR: Failed to create path to ipcfg file\n");
+      return -ENOMEM;
+    }
+
+  /* Now open the file */
+
+  *stream = fopen(path, mode);
+  ret     = OK;
+
+  if (*stream == NULL)
+    {
+      ret = -errno;
+      fprintf(stderr, "ERROR: Failed to open %s: %d\n", path, ret);
+    }
+
+  free(path);
+  return ret;
+}
+#endif
+
+/****************************************************************************
+ * Name: ipcfg_open (for binary mode)
+ *
+ * Description:
+ *   Form the complete path to the ipcfg file and open it.
+ *
+ * Input Parameters:
+ *   netdev - The network device.  For examplel "eth0"
+ *   oflags - File open flags
+ *   mode   - File creation mode
+ *
+ * Returned Value:
+ *   The open file descriptor is returned on success; a negated errno value
+ *   is returned on any failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_IPCFG_BINARY
+static int ipcfg_open(FAR const char *netdev, int oflags, mode_t mode)
+{
+  FAR char *path;
+  int fd;
+  int ret;
+
+  /* Create the full path to the ipcfg file for the network device */
+
+  path = ipcfg_allocpath(netdev);
+  if (path == NULL)
+    {
+      /* Assume failure to allocate memory */
+
+      fprintf(stderr, "ERROR: Failed to create path to ipcfg file\n");
+      return -ENOMEM;
+    }
+
+  /* Now open the file */
+
+  fd  = open(path, oflags, mode);
+  if (fd < 0)
+    {
+      ret = -errno;
+      fprintf(stderr, "ERROR: Failed to open %s: %d\n", path, ret);
+      goto errout_with_path;
+    }
+
+#if defined(CONFIG_IPCFG_OFFSET) && CONFIG_IPCFG_OFFSET > 0
+  /* If the binary file is accessed on a character device as a binary
+   * file, then there is also an option to seek to a location on the
+   * media before reading or writing the file.
+   */
+
+  ret = lseek(fd, CONFIG_IPCFG_OFFSET, SEEK_SET);
+  if (ret < 0)
+    {
+      ret = -errno;
+      close(fd);
+      fprintf(stderr, "ERROR: Failed to seek to $ld: %d\n",
+              (long)CONFIG_IPCFG_OFFSET, ret);
+      goto errout_with_path;
+    }
+
+#endif
+  ret = fd;
+
+errout_with_path:
+  free(path);
+  return ret;
+}
+#endif
+
+/****************************************************************************
+ * Name: ipcfg_trim
+ *
+ * Description:
+ *   Skip over any whitespace.
+ *
+ * Input Parameters:
+ *   line  - Pointer to line buffer
+ *   index - Current index into the line buffer
+ *
+ * Returned Value:
+ *   New value of index.
+ *
+ ****************************************************************************/
+
+#ifndef CONFIG_IPCFG_BINARY
+static int ipcfg_trim(FAR char *line, int index)
+{
+  int ret;
+  while (line[index] != '\0' && isspace(line[index]))
+    {
+      index++;
+    }
+
+  ret = index;
+  while (line[index] != '\0')
+    {
+      if (!isprint(line[index]))
+        {
+          line[index] = '\0';
+          break;
+        }
+
+      index++;
+    }
+
+  return ret;
+}
+#endif
+
+/****************************************************************************
+ * Name: ipcfg_putaddr
+ *
+ * Description:
+ *   Write a <variable>=<address> value pair to the stream.
+ *
+ * Input Parameters:
+ *   stream   - The output stream
+ *   variable - The variable namespace
+ *   address  - The IP address to write
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_IPCFG_WRITABLE) && !defined(CONFIG_IPCFG_BINARY)
+static void ipcfg_putaddr(FAR FILE *stream, FAR const char *variable,
+                          in_addr_t address)
+{
+  /* REVISIT:  inet_ntoa() is not thread safe. */
+
+  if (address != 0)
+    {
+      struct in_addr saddr =
+      {
+        address
+      };
+
+      fprintf(stream, "%s=%s\n", variable, inet_ntoa(saddr));
+    }
+}
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ipcfg_read
+ *
+ * Description:
+ *   Read and parse the IP configuration file for the specified network
+ *   device.
+ *
+ * Input Parameters:
+ *   netdev - The network device.  For examplel "eth0"
+ *   ipcfg  - Pointer to a user provided location to receive the IP
+ *            configuration.  Refers to either struct ipv4cfg_s or
+ *            ipv6cfg_s, depending on the value of af.
+ *   af     - Identifies the address family whose IP configuration is
+ *            requested.  May be either AF_INET or AF_INET6.
+ *
+ * Returned Value:
+ *   Zero is returned on success; a negated errno value is returned on any
+ *   failure.
+ *
+ ****************************************************************************/
+
+int ipcfg_read(FAR const char *netdev, FAR void *ipcfg, sa_family_t af)
+{
+#ifdef CONFIG_IPCFG_BINARY
+  FAR struct ipv4cfg_s *ipv4cfg = (FAR struct ipv4cfg_s *)ipcfg;
+  struct ipcfg_header_s hdr;
+  ssize_t nread;
+  int fd;
+  int ret;
+
+  DEBUGASSERT(netdev != NULL && ipv4cfg != NULL && af == AF_INET);
+
+  /* Open the file */
+
+  fd = ipcfg_open(netdev, O_RDONLY, 0666);
+  if (fd < 0)
+    {
+      return fd;
+    }
+
+  /* Read the header */
+
+  nread = read(fd, &hdr, sizeof(struct ipcfg_header_s));
+  if (nread < 0)
+    {
+      ret = -errno;
+      fprintf(stderr, "ERROR: Failed to read file: %d\n", ret);
+      goto errout_with_fd;
+    }
+  else if (nread != sizeof(struct ipcfg_header_s))
+    {
+      ret = -EIO;
+      fprintf(stderr, "ERROR: Bad read size: %ld\n", (long)nread);
+      goto errout_with_fd;
+    }
+
+  /* Verify the header.  Only a single IPv4 header is anticipated */
+
+  if (hdr.next != 0 || hdr.type != AF_INET)
+    {
+      ret = -EINVAL;
+      fprintf(stderr, "ERROR: Bad header: {%u,%u}\n",
+              hdr.next, hdr.type);
+      goto errout_with_fd;
+    }
+
+  /* Read the file content */
+
+  nread = read(fd, ipv4cfg, sizeof(struct ipv4cfg_s));
+  if (nread < 0)
+    {
+      ret = -errno;
+      fprintf(stderr, "ERROR: Failed to read file: %d\n", ret);
+    }
+  else if (nread != sizeof(struct ipv4cfg_s))
+    {
+      ret = -EIO;
+      fprintf(stderr, "ERROR: Bad read size: %ld\n", (long)nread);
+    }
+  else
+    {
+      ret = OK;
+    }
+
+errout_with_fd:
+  close(fd);
+  return ret;
+
+#else
+  FAR struct ipv4cfg_s *ipv4cfg = (FAR struct ipv4cfg_s *)ipcfg;
+  FAR FILE *stream;
+  char line[MAX_LINESIZE];
+  int index;
+  int ret;
+
+  DEBUGASSERT(netdev != NULL && ipv4cfg != NULL && af == AF_INET);
+
+  /* Open the file */
+
+  ret = ipcfg_open(netdev, &stream, "r");
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  /* Process each line in the file */
+
+  memset(ipv4cfg, 0, sizeof(FAR struct ipv4cfg_s));
+
+  while (fgets(line, MAX_LINESIZE, stream) != NULL)
+    {
+      /* Skip any leading whitespace */
+
+      index = ipcfg_trim(line, 0);
+
+      /* Check for a blank line or a comment */
+
+      if (line[index] != '\0' && line[index] != '#')
+        {
+          FAR char *variable = &line[index];
+          FAR char *value;
+
+          /* Expect <variable>=<value> pair */
+
+          value = strchr(variable, '=');
+          if (value == NULL)
+            {
+              fprintf(stderr, "ERROR: Skipping malformed line in file: %s\n",
+                      line);
+              continue;
+            }
+
+          /* NUL-terminate the variable string */
+
+          *value++ = '\0';
+
+          /* Process the variable assignment */
+
+          if (strcmp(variable, "DEVICE") == 0)
+            {
+              /* Just assure that it matches the filename */
+
+              if (strcmp(value, netdev) != 0)
+                {
+                  fprintf(stderr, "ERROR: Bad device in file: %s=%s\n",
+                          variable, value);
+                }
+            }
+          else if (strcmp(variable, "IPv4PROTO") == 0)
+            {
+              if (strcmp(value, "none") == 0)
+                {
+                  ipv4cfg->proto = IPv4PROTO_NONE;
+                }
+              else if (strcmp(value, "static") == 0)
+                {
+                  ipv4cfg->proto = IPv4PROTO_STATIC;
+                }
+              else if (strcmp(value, "dhcp") == 0)
+                {
+                  ipv4cfg->proto = IPv4PROTO_DHCP;
+                }
+              else if (strcmp(value, "fallback") == 0)
+                {
+                  ipv4cfg->proto = IPv4PROTO_FALLBACK;
+                }
+              else
+                {
+                  fprintf(stderr, "ERROR: Unrecognized IPv4PROTO: %s=%s\n",
+                          variable, value);
+                }
+            }
+          else if (strcmp(variable, "IPv4IPADDR") == 0)
+            {
+              ipv4cfg->ipaddr = inet_addr(value);
+            }
+          else if (strcmp(variable, "IPv4NETMASK") == 0)
+            {
+              ipv4cfg->netmask = inet_addr(value);
+            }
+          else if (strcmp(variable, "IPv4ROUTER") == 0)
+            {
+              ipv4cfg->router = inet_addr(value);
+            }
+          else if (strcmp(variable, "IPv4DNS") == 0)
+            {
+              ipv4cfg->dnsaddr = inet_addr(value);
+            }
+          else
+            {
+              fprintf(stderr, "ERROR: Unrecognized variable: %s=%s\n",
+                     variable, value);
+            }
+        }
+    }
+
+  /* Close the file and return */
+
+  fclose(stream);
+  return OK;
+#endif
+}
+
+/****************************************************************************
+ * Name: ipcfg_write
+ *
+ * Description:
+ *   Write the IP configuration file for the specified network device.
+ *
+ * Input Parameters:
+ *   netdev - The network device.  For examplel "eth0"
+ *   ipcfg  - The IP configuration to be written.  Refers to either struct
+ *            ipv4cfg_s or ipv6cfg_s, depending on the value of af.
+ *   af     - Identifies the address family whose IP configuration is
+ *            to be written.  May be either AF_INET or AF_INET6.
+ *
+ * Returned Value:
+ *   Zero is returned on success; a negated errno value is returned on any
+ *   failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_IPCFG_WRITABLE
+int ipcfg_write(FAR const char *netdev, FAR const void *ipcfg,
+                sa_family_t af)
+{
+#ifdef CONFIG_IPCFG_BINARY
+  FAR struct ipv4cfg_s *ipv4cfg = (FAR struct ipv4cfg_s *)ipcfg;
+  struct ipcfg_header_s hdr;
+  ssize_t nwritten;
+  int fd;
+  int ret;
+
+  DEBUGASSERT(netdev != NULL && ipv4cfg != NULL && af == AF_INET);
+
+  /* Open the file */
+
+  fd = ipcfg_open(netdev, O_WRONLY | O_TRUNC | O_CREAT, 0666);
+  if (fd < 0)
+    {
+      return fd;
+    }
+
+  /* Write the file header */
+
+  hdr.next = 0;
+  hdr.type = AF_INET;
+
+  nwritten = write(fd, &hdr, sizeof(struct ipcfg_header_s));
+  if (nwritten < 0)
+    {
+      ret = -errno;
+      fprintf(stderr, "ERROR: Failed to write to file: %d\n", ret);
+      goto errout_with_fd;
+    }
+  else if (nwritten != sizeof(struct ipcfg_header_s))
+    {
+      ret = -EIO;
+      fprintf(stderr, "ERROR: Bad write size: %ld\n", (long)nwritten);
+      goto errout_with_fd;
+    }
+
+  /* Write the file content */
+
+  nwritten = write(fd, ipv4cfg, sizeof(struct ipv4cfg_s));
+  if (nwritten < 0)
+    {
+      ret = -errno;
+      fprintf(stderr, "ERROR: Failed to write file: %d\n", ret);
+    }
+  else if (nwritten != sizeof(struct ipv4cfg_s))
+    {
+      ret = -EIO;
+      fprintf(stderr, "ERROR: Bad write size: %ld\n", (long)nwritten);
+    }
+  else
+    {
+      ret = OK;
+    }
+
+errout_with_fd:
+  close(fd);
+  return ret;
+
+#else
+  FAR struct ipv4cfg_s *ipv4cfg = (FAR struct ipv4cfg_s *)ipcfg;
+  FAR FILE *stream;
+  int ret;
+
+  DEBUGASSERT(netdev != NULL && ipv4cfg != NULL && af == AF_INET);
+
+  /* Open the file */
+
+  ret = ipcfg_open(netdev, &stream, "w");
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  /* Format and write the file */
+
+  if ((unsigned)ipv4cfg->proto > MAX_IPv4PROTO)
+    {
+      fprintf(stderr, "ERROR: Unrecognized IPv4PROTO value: %d\n",
+              ipv4cfg->proto);
+      return -EINVAL;
+    }
+
+  fprintf(stream, "DEVICE=%s\n", netdev);
+  fprintf(stream, "IPv4PROTO=%s\n", g_ipv4proto_name[ipv4cfg->proto]);
+
+  ipcfg_putaddr(stream, "IPv4IPADDR",  ipv4cfg->ipaddr);
+  ipcfg_putaddr(stream, "IPv4NETMASK", ipv4cfg->netmask);
+  ipcfg_putaddr(stream, "IPv4ROUTER",  ipv4cfg->router);
+  ipcfg_putaddr(stream, "IPv4DNS",     ipv4cfg->dnsaddr);
+
+  /* Close the file and return */
+
+  fclose(stream);
+  return OK;
+#endif
+}
+#endif

--- a/fsutils/ipcfg/ipcfg.c
+++ b/fsutils/ipcfg/ipcfg.c
@@ -38,9 +38,9 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-
-#define MAX_LINESIZE  80
-#define MAX_IPv4PROTO IPv4PROTO_FALLBACK
+#define IPCFG_VERSION  0  /* Increment this if the data/structure changes */
+#define MAX_LINESIZE   80
+#define MAX_IPv4PROTO  IPv4PROTO_FALLBACK
 
 /* Values for the record type field */
 
@@ -53,6 +53,7 @@
 struct ipcfg_header_s
 {
   uint8_t next;         /* Offset to the next IP configuration record */
+  uint8_t version;
   sa_family_t type;     /* Must be AF_INET */
 };
 
@@ -383,7 +384,7 @@ int ipcfg_read(FAR const char *netdev, FAR void *ipcfg, sa_family_t af)
 
   /* Verify the header.  Only a single IPv4 header is anticipated */
 
-  if (hdr.next != 0 || hdr.type != AF_INET)
+  if (hdr.version != IPCFG_VERSION || hdr.next != 0 || hdr.type != AF_INET)
     {
       ret = -EINVAL;
       fprintf(stderr, "ERROR: Bad header: {%u,%u}\n",
@@ -570,8 +571,9 @@ int ipcfg_write(FAR const char *netdev, FAR const void *ipcfg,
 
   /* Write the file header */
 
-  hdr.next = 0;
-  hdr.type = AF_INET;
+  hdr.next    = 0;
+  hdr.type    = AF_INET;
+  hdr.version = IPCFG_VERSION;
 
   nwritten = write(fd, &hdr, sizeof(struct ipcfg_header_s));
   if (nwritten < 0)

--- a/include/fsutils/ipcfg.h
+++ b/include/fsutils/ipcfg.h
@@ -1,0 +1,205 @@
+/****************************************************************************
+ * apps/include/fsutils/ipcfg.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __APPS_INCLUDE_FSUTILS_IPCFG_H
+#define __APPS_INCLUDE_FSUTILS_IPCFG_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <netinet/in.h>
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* The structure contains the parsed content of the ipcfg-<dev> file.
+ * Summary of file content:
+ *
+ * Common Settings:
+ *
+ * DEVICE=name
+ *   where name is the name of the physical device.
+ *
+ * IPv4 Settings:
+ *
+ * IPv4BOOTPROTO=protocol
+ *   where protocol is one of the following:
+ *
+ *     none     - No protocol selected
+ *     static   - Use static IP
+ *     dhcp     - The DHCP protocol should be used
+ *     fallback - Use DHCP with fall back static IP
+ *
+ * All of the following addresses are in network order.  The special value
+ * zero is used to indicate that the address is not available:
+ *
+ * IPv4ADDR=address
+ *    where address is the IPv4 address.  Used only with static or fallback
+ *    protocols.
+ *
+ * IPv4NETMASK=address
+ *    where address is the netmask.  Used only with static or fallback
+ *    protocols.
+ *
+ * IPv4ROUTER=address
+ *    where address is the IPv4 default router address.  Used only with
+ *    static or fallback protocols.
+ *
+ * IPv4DNS=address
+ *   where address is a (optional) name server address.
+ */
+
+/* Values for the IPv4BOOTPROTO setting */
+
+enum ipv4cfg_bootproto_e
+{
+  IPv4PROTO_NONE     = 0, /* No protocol assigned */
+  IPv4PROTO_STATIC   = 1, /* Use static IP */
+  IPv4PROTO_DHCP     = 2, /* Use DHCP */
+  IPv4PROTO_FALLBACK = 3  /* Use DHCP with fall back static IP */
+};
+
+struct ipv4cfg_s
+{
+  enum ipv4cfg_bootproto_e proto; /* Configure for static and/or DHCP */
+
+  /* The following fields are required for static/fallback configurations */
+
+  in_addr_t ipaddr;             /* IPv4 address */
+  in_addr_t netmask;            /* Network mask */
+  in_addr_t router;             /* Default router */
+
+  /* The following fields are optional for dhcp and fallback configurations */
+
+  in_addr_t dnsaddr;            /* Name server address */
+};
+
+/* IPv6 Settings:
+ *
+ * IPv6BOOTPROTO=protocol
+ *   where protocol is one of the following:
+ *
+ *     none     - No protocol selected
+ *     static   - Use static IP
+ *     autoconf - ICMPv6 auto-configuration should be used
+ *     fallback - Use auto-configuration with fall back static IP
+ *
+ * All of the following addresses are in network order.  The special value
+ * zero is used to indicate that the address is not available:
+ *
+ * IPv6ADDR=address
+ *    where address is the IPv6 address.  Used only with static or fallback
+ *    protocols.
+ *
+ * IPv6NETMASK=address
+ *    where address is the netmask.  Used only with static or fallback
+ *    protocols.
+ *
+ * IPv6ROUTER=address
+ *    where address is the IPv6 default router address.  Used only with
+ *    static or fallback protocols.
+ */
+
+/* Values for the IPv6BOOTPROTO setting */
+
+enum ipv6cfg_bootproto_e
+{
+  BOOTPROTO_NONE     = 0, /* No protocol assigned */
+  BOOTPROTO_STATIC   = 1, /* Use static IP */
+  BOOTPROTO_AUTOCONF = 2, /* Use ICMPv6 auto-configuration */
+  BOOTPROTO_FALLBACK = 3  /* Use auto-configuration with fall back static IP */
+};
+
+struct ipv6cfg_s
+{
+  enum ipv6cfg_bootproto_e proto; /* Configure for static and/or autoconfig */
+
+  /* The following fields are required for static/fallback configurations */
+
+  struct in6_addr ipaddr;       /* IPv6 address */
+  struct in6_addr netmask;      /* Network mask */
+  struct in6_addr router;       /* Default router */
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: ipcfg_read
+ *
+ * Description:
+ *   Read and parse the IP configuration file for the specified network
+ *   device.
+ *
+ * Input Parameters:
+ *   netdev - The network device.  For examplel "eth0"
+ *   ipcfg  - Pointer to a user provided location to receive the IP
+ *            configuration.  Refers to either struct ipv4cfg_s or
+ *            ipv6cfg_s, depending on the value of af.
+ *   af     - Identifies the address family whose IP configuration is
+ *            requested.  May be either AF_INET or AF_INET6.
+ *
+ * Returned Value:
+ *   Zero is returned on success; a negated errno value is returned on any
+ *   failure.
+ *
+ ****************************************************************************/
+
+int ipcfg_read(FAR const char *netdev, FAR void *ipcfg, sa_family_t af);
+
+/****************************************************************************
+ * Name: ipcfg_write
+ *
+ * Description:
+ *   Write the IP configuration file for the specified network device.
+ *
+ * Input Parameters:
+ *   netdev - The network device.  For examplel "eth0"
+ *   ipcfg  - The IP configuration to be written.  Refers to either struct
+ *            ipv4cfg_s or ipv6cfg_s, depending on the value of af.
+ *   af     - Identifies the address family whose IP configuration is
+ *            to be written.  May be either AF_INET or AF_INET6.
+ *
+ * Returned Value:
+ *   Zero is returned on success; a negated errno value is returned on any
+ *   failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_IPCFG_WRITABLE
+int ipcfg_write(FAR const char *netdev, FAR const void *ipcfg,
+                sa_family_t af);
+#endif
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __APPS_INCLUDE_FSUTILS_IPCFG_H */

--- a/include/netutils/netinit.h
+++ b/include/netutils/netinit.h
@@ -74,7 +74,8 @@
 #  define CONFIG_NETINIT_MACADDR   0x00e0deadbeef
 #endif
 
-#if !defined(CONFIG_NETINIT_THREAD) || !defined(CONFIG_ARCH_PHY_INTERRUPT) || \
+#if !defined(CONFIG_NETINIT_THREAD) || \
+    !(defined(CONFIG_ARCH_PHY_INTERRUPT) || defined(CONFIG_ARCH_PHY_POLLED)) || \
     !defined(CONFIG_NETDEV_PHY_IOCTL) || !defined(CONFIG_NET_UDP)
 #  undef CONFIG_NETINIT_MONITOR
 #endif

--- a/netutils/netinit/Kconfig
+++ b/netutils/netinit/Kconfig
@@ -73,7 +73,7 @@ if NETINIT_THREAD
 config NETINIT_MONITOR
 	bool "Monitor link state"
 	default n
-	depends on ARCH_PHY_INTERRUPT && NETDEV_PHY_IOCTL && NET_UDP
+	depends on (ARCH_PHY_INTERRUPT || ARCH_PHY_POLLED) && NETDEV_PHY_IOCTL && NET_UDP
 	---help---
 		By default the net initialization thread will bring-up the network
 		then exit, freeing all of the resources that it required.  This is a
@@ -87,10 +87,38 @@ config NETINIT_MONITOR
 		required for network initialization are never released.
 
 if NETINIT_MONITOR
+config NETINIT_ESTABLISH_POLL_RATE
+	int "The poll rate in seconds, to check for link establishment."
+	default 2
+	depends on !ARCH_PHY_INTERRUPT && ARCH_PHY_POLLED
+	---help---
+		The network monitor will check the PHY link state every
+		NETINIT_ESTABLISH_POLL_RATE seconds for link establishment.
+
+config NETINIT_LOSS_POLL_RATE
+	int "The poll rate in seconds, to check for link loss."
+	default 3
+	depends on !ARCH_PHY_INTERRUPT && ARCH_PHY_POLLED
+	---help---
+		The network monitor will check the PHY link state every
+		NETINIT_LOSS_POLL_RATE seconds for link loss.
+
+config NETINIT_DHCP_FALLBACK
+	int "The number of failed DHCP attempts to fall back to using static settings"
+	default 5
+	depends on NETINIT_DHCPC && !ARCH_PHY_INTERRUPT && ARCH_PHY_POLLED && FSUTILS_IPCFG
+	---help---
+		When the network monitor is used with FSUTILS_IPCFG if, the
+		the BOOTPROTO_FALLBACK is the active protocol. NETINIT_DHCP_FALLBACK will
+		be used as the number of times, DHCP will be be attempted before
+		falling back to using the static settings. The time will be roughly
+		NETINIT_LOSS_POLL_RATE * NETINIT_DHCP_FALLBACK seconds.
+		Setting this value to 0, will disable this feature.
 
 config NETINIT_SIGNO
 	int "Notification signal number"
 	default 18
+	depends on ARCH_PHY_INTERRUPT && !ARCH_PHY_POLLED
 	---help---
 		The network monitor logic will receive signals when there is any
 		change in the link status.  This setting may be used to customize

--- a/netutils/netinit/netinit.c
+++ b/netutils/netinit/netinit.c
@@ -1,9 +1,10 @@
 /****************************************************************************
  * apps/netutils/netinit/netinit.c
  *
- *   Copyright (C) 2010-2012, 2014-2016, 2019 Gregory Nutt. All rights
+ *   Copyright (C) 2010-2012, 2014-2016, 2019-2020 Gregory Nutt. All rights
  *     reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *   AuthorS: Gregory Nutt <gnutt@nuttx.org>
+ *            David Sidrane <david.sidrane@nscdg.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -61,6 +62,10 @@
 #include <netinet/in.h>
 
 #include <nuttx/net/mii.h>
+
+#if defined(CONFIG_FSUTILS_IPCFG)
+#  include <fsutils/ipcfg.h>
+#endif
 
 #include "netutils/netlib.h"
 #if defined(CONFIG_NETINIT_DHCPC) || defined(CONFIG_NETINIT_DNS)
@@ -221,17 +226,36 @@
 #  define AF_INETX AF_INET6
 #endif
 
-/* While the network is up, the network monitor really does nothing.  It
- * will wait for a very long time while waiting, it can be awakened by a
- * signal indicating a change in network status.
+/* If using signal notification, raise by a the PHY, then while the network
+ * is up, the network monitor really does nothing.  It will wait for a very
+ * long time while waiting, it can be awakened by a signal indicating a
+ * change in network status.
+ *
+ * If the network monitor is used in polled mode these values are set by the
+ * CONFIG_NETINIT_LOSS_POLL_RATE and CONFIG_NETINIT_ESTABLISH_POLL_RATE
  */
 
-#define LONG_TIME_SEC    (60*60) /* One hour in seconds */
-#define SHORT_TIME_SEC   (2)     /* 2 seconds */
+#if !(defined(CONFIG_ARCH_PHY_POLLED))
+#  define LONG_TIME_SEC    (60*60) /* One hour in seconds */
+#  define SHORT_TIME_SEC   (2)     /* 2 seconds */
+#else
+#  define LONG_TIME_SEC    (CONFIG_NETINIT_LOSS_POLL_RATE)
+#  define SHORT_TIME_SEC   (CONFIG_NETINIT_ESTABLISH_POLL_RATE)
+#endif
 
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+#ifdef CONFIG_NETINIT_DHCPC
+static struct dhcpc_state g_ds;
+#endif
+#if defined(CONFIG_FSUTILS_IPCFG)
+static struct ipv4cfg_s g_netconf;
+#  if defined(CONFIG_NETINIT_DHCP_FALLBACK) && CONFIG_NETINIT_DHCP_FALLBACK > 0
+#    define USE_DHCP_FALLBACK 1
+#  endif
+#endif
 
 #ifdef CONFIG_NETINIT_MONITOR
 static sem_t g_notify_sem;
@@ -343,6 +367,86 @@ static void netinit_set_macaddr(void)
 #  define netinit_set_macaddr()
 #endif
 
+#ifdef CONFIG_FSUTILS_IPCFG
+/****************************************************************************
+ * Name: netinit_get_ipaddrs
+ *
+ * Description:
+ *   Setup IP addresses.
+ *
+ *   For 6LoWPAN, the IP address derives from the MAC address.  Setting it
+ *   to any user provided value is asking for trouble.
+ *
+ ****************************************************************************/
+
+static int netinit_get_ipaddrs(void)
+{
+#ifdef CONFIG_NETINIT_DHCPC
+  bool use_dhcp   = false;
+#endif
+  bool use_static = false;
+#ifdef CONFIG_NET_IPv4
+  struct in_addr addr;
+  int ret;
+
+  ret = ipcfg_read(NET_DEVNAME, (FAR struct ipcfg_s *) &g_netconf, AF_INET);
+  if (ret < 0)
+    {
+      return ret;
+    }
+  else
+    {
+      use_static = g_netconf.proto & BOOTPROTO_STATIC;
+
+#ifdef CONFIG_NETINIT_DHCPC
+      use_dhcp = g_netconf.proto & IPv4PROTO_DHCP;
+      addr.s_addr = use_dhcp ? 0 : HTONL(g_netconf.ipaddr);
+#else
+      addr.s_addr = HTONL(g_netconf.ipaddr);
+#endif
+      netlib_set_ipv4addr(NET_DEVNAME, &addr);
+
+      /* Set up the default router address */
+
+      addr.s_addr = use_static ? HTONL(g_netconf.router) : 0;
+      netlib_set_dripv4addr(NET_DEVNAME, &addr);
+
+      /* Setup the subnet mask */
+
+      addr.s_addr = use_static ? HTONL(g_netconf.netmask) : 0;
+      netlib_set_ipv4netmask(NET_DEVNAME, &addr);
+#endif
+
+#ifdef CONFIG_NET_IPv6
+#ifndef CONFIG_NET_ICMPv6_AUTOCONF
+  /* Set up our fixed host address */
+
+  netlib_set_ipv6addr(NET_DEVNAME,
+                      (FAR const struct in6_addr *)g_ipv6_hostaddr);
+
+  /* Set up the default router address */
+
+  netlib_set_dripv6addr(NET_DEVNAME,
+                        (FAR const struct in6_addr *)g_ipv6_draddr);
+
+  /* Setup the subnet mask */
+
+  netlib_set_ipv6netmask(NET_DEVNAME,
+                        (FAR const struct in6_addr *)g_ipv6_netmask);
+
+#endif /* CONFIG_NET_ICMPv6_AUTOCONF */
+#endif /* CONFIG_NET_IPv6 */
+
+#ifdef CONFIG_NETINIT_DNS
+  addr.s_addr = use_static ? HTONL(g_netconf.dnsaddr) : 0;
+  netlib_set_ipv4dnsaddr(&addr);
+#endif
+    }
+
+  return OK;
+}
+#endif
+
 /****************************************************************************
  * Name: netinit_set_ipaddrs
  *
@@ -358,6 +462,13 @@ static void netinit_set_macaddr(void)
     defined(CONFIG_NET_IEEE802154)
 static void netinit_set_ipaddrs(void)
 {
+#ifdef CONFIG_FSUTILS_IPCFG
+  if (netinit_get_ipaddrs() == OK)
+    {
+      return;
+    }
+
+#endif
 #ifdef CONFIG_NET_IPv4
   struct in_addr addr;
 
@@ -411,6 +522,71 @@ static void netinit_set_ipaddrs(void)
 #endif
 
 /****************************************************************************
+ * Name: netinit_dhcp()
+ *
+ * Description:
+ *   Renew or obtain a IP Address over DHCP
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NETINIT_DHCPC
+static int netinit_dhcp(struct dhcpc_state *ds)
+{
+  uint8_t mac[IFHWADDRLEN];
+  FAR void *handle;
+  int ret = -EAGAIN;
+#ifdef CONFIG_FSUTILS_IPCFG
+  if ((g_netconf.proto & IPv4PROTO_DHCP) == 0)
+    {
+      return -ENOSYS;
+    }
+#endif
+
+  /* Get the MAC address of the NIC */
+
+  netlib_getmacaddr(NET_DEVNAME, mac);
+
+  /* Set up the DHCPC modules */
+
+  handle = dhcpc_open(NET_DEVNAME, &mac, IFHWADDRLEN);
+  if (handle == NULL)
+    {
+      return ret;
+    }
+
+  /* Get an IP address.  Note that there is no logic for renewing the
+   * IP address in this example. The address should be renewed in
+   * (ds.lease_time / 2) seconds.
+   */
+
+  ret = dhcpc_request(handle, ds) ;
+
+  if (ret == OK)
+    {
+      netlib_set_ipv4addr(NET_DEVNAME, &ds->ipaddr);
+
+      if (ds->netmask.s_addr != 0)
+        {
+          netlib_set_ipv4netmask(NET_DEVNAME, &ds->netmask);
+        }
+
+      if (ds->default_router.s_addr != 0)
+        {
+          netlib_set_dripv4addr(NET_DEVNAME, &ds->default_router);
+        }
+
+      if (ds->dnsaddr.s_addr != 0)
+        {
+          netlib_set_ipv4dnsaddr(&ds->dnsaddr);
+        }
+    }
+
+  dhcpc_close(handle);
+  return ret;
+}
+#endif
+
+/****************************************************************************
  * Name: netinit_net_bringup()
  *
  * Description:
@@ -421,12 +597,6 @@ static void netinit_set_ipaddrs(void)
 #if defined(NETINIT_HAVE_NETDEV) && !defined(CONFIG_NETINIT_NETLOCAL)
 static void netinit_net_bringup(void)
 {
-#ifdef CONFIG_NETINIT_DHCPC
-  uint8_t mac[IFHWADDRLEN];
-  struct dhcpc_state ds;
-  FAR void *handle;
-#endif
-
   /* Bring the network up. */
 
   if (netlib_ifup(NET_DEVNAME) < 0)
@@ -450,44 +620,7 @@ static void netinit_net_bringup(void)
 #endif
 
 #ifdef CONFIG_NETINIT_DHCPC
-  /* Get the MAC address of the NIC */
-
-  netlib_getmacaddr(NET_DEVNAME, mac);
-
-  /* Set up the DHCPC modules */
-
-  handle = dhcpc_open(NET_DEVNAME, &mac, IFHWADDRLEN);
-  if (handle == NULL)
-    {
-      return;
-    }
-
-  /* Get an IP address.  Note that there is no logic for renewing the
-   * IP address in this example. The address should be renewed in
-   * (ds.lease_time / 2) seconds.
-   */
-
-  if (dhcpc_request(handle, &ds) == OK)
-    {
-      netlib_set_ipv4addr(NET_DEVNAME, &ds.ipaddr);
-
-      if (ds.netmask.s_addr != 0)
-        {
-          netlib_set_ipv4netmask(NET_DEVNAME, &ds.netmask);
-        }
-
-      if (ds.default_router.s_addr != 0)
-        {
-          netlib_set_dripv4addr(NET_DEVNAME, &ds.default_router);
-        }
-
-      if (ds.dnsaddr.s_addr != 0)
-        {
-          netlib_set_ipv4dnsaddr(&ds.dnsaddr);
-        }
-    }
-
-  dhcpc_close(handle);
+  netinit_dhcp(&g_ds);
 #endif
 
 #ifdef CONFIG_NETUTILS_NTPCLIENT
@@ -524,6 +657,10 @@ static void netinit_configure(void)
 #ifndef CONFIG_NETINIT_NETLOCAL
   /* Bring the network up. */
 
+#ifdef CONFIG_NETINIT_DHCPC
+    memset(&g_ds, 0, sizeof(g_ds));
+#endif
+
   netinit_net_bringup();
 #endif
 #endif /* NETINIT_HAVE_NETDEV */
@@ -537,7 +674,7 @@ static void netinit_configure(void)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_NETINIT_MONITOR
+#if defined(CONFIG_NETINIT_MONITOR) && !defined(CONFIG_ARCH_PHY_POLLED)
 static void netinit_signal(int signo, FAR siginfo_t *siginfo,
                                FAR void * context)
 {
@@ -573,8 +710,16 @@ static int netinit_monitor(void)
   struct timespec abstime;
   struct timespec reltime;
   struct ifreq ifr;
+#if !defined(CONFIG_ARCH_PHY_POLLED)
   struct sigaction act;
   struct sigaction oact;
+#endif
+#ifdef CONFIG_NETINIT_DHCPC
+  struct timespec dhcprenew;
+#  if defined(USE_DHCP_FALLBACK)
+  int dhcp_fail_count = 0;
+#  endif
+#endif
   bool devup;
   int ret;
   int sd;
@@ -599,6 +744,7 @@ static int netinit_monitor(void)
       goto errout;
     }
 
+#if !defined(CONFIG_ARCH_PHY_POLLED)
   /* Attach a signal handler so that we do not lose PHY events */
 
   act.sa_sigaction = netinit_signal;
@@ -614,6 +760,19 @@ static int netinit_monitor(void)
       goto errout_with_socket;
     }
 
+#endif
+
+#ifdef CONFIG_NETINIT_DHCPC
+  /* We assume that the netinit_thread was able to get a lease
+   * If it did we set up the renew point at lease_time / 2
+   * if it did not the renew point is now.
+   */
+
+  DEBUGVERIFY(clock_gettime(CLOCK_REALTIME, &dhcprenew));
+  dhcprenew.tv_sec  += g_ds.lease_time / 2;
+  dhcprenew.tv_nsec = 0;
+#endif
+
   /* Now loop, waiting for changes in link status */
 
   for (; ; )
@@ -626,6 +785,7 @@ static int netinit_monitor(void)
       ifr.ifr_mii_notify_event.sigev_notify = SIGEV_SIGNAL;
       ifr.ifr_mii_notify_event.sigev_signo  = CONFIG_NETINIT_SIGNO;
 
+#if !defined(CONFIG_ARCH_PHY_POLLED)
       ret = ioctl(sd, SIOCMIINOTIFY, (unsigned long)&ifr);
       if (ret < 0)
         {
@@ -636,6 +796,7 @@ static int netinit_monitor(void)
           goto errout_with_sigaction;
         }
 
+#endif
       /* Does the driver think that the link is up or down? */
 
       ret = ioctl(sd, SIOCGIFFLAGS, (unsigned long)&ifr);
@@ -720,6 +881,80 @@ static int netinit_monitor(void)
             {
               /* The link is still up.  Take a long, well-deserved rest */
 
+#ifdef CONFIG_NETINIT_DHCPC
+              /* Get Current time */
+
+              DEBUGVERIFY(clock_gettime(CLOCK_REALTIME, &abstime));
+
+              /* Did we ever get a lease */
+#ifdef CONFIG_FSUTILS_IPCFG
+              if (g_ds.lease_time == 0 && (g_netconf.proto & IPv4PROTO_DHCP))
+#else
+              if (g_ds.lease_time == 0)
+#endif
+                {
+                  /* No so, let's try to bring up the network */
+
+                  netinit_net_bringup();
+
+                  /* Did we get a lease */
+
+                  if (g_ds.lease_time != 0)
+                    {
+                      /* Yes, set next renewal time */
+
+                      DEBUGVERIFY(clock_gettime(CLOCK_REALTIME, &dhcprenew));
+                      dhcprenew.tv_sec  += g_ds.lease_time / 2;
+                    }
+#if defined(USE_DHCP_FALLBACK)
+                  else
+                    {
+                      if ((g_netconf.proto & BOOTPROTO_FALLBACK) ==
+                          BOOTPROTO_FALLBACK &&
+                          ++dhcp_fail_count > CONFIG_NETINIT_DHCP_FALLBACK)
+                        {
+                          struct in_addr addr;
+                          g_netconf.proto &= ~IPv4PROTO_DHCP;
+                          addr.s_addr = HTONL(g_netconf.ipaddr);
+                          netlib_set_ipv4addr(NET_DEVNAME, &addr);
+                        }
+                    }
+#endif
+                }
+#ifdef CONFIG_FSUTILS_IPCFG
+              else if (abstime.tv_sec > dhcprenew.tv_sec && g_netconf.proto &
+                  IPv4PROTO_DHCP)
+#else
+              else if (abstime.tv_sec > dhcprenew.tv_sec)
+#endif
+                {
+                  /* Do the renew */
+
+                  ret = netinit_dhcp(&g_ds);
+                  if (ret == OK)
+                    {
+                      /* Yes, set next renewal time */
+
+                      DEBUGVERIFY(clock_gettime(CLOCK_REALTIME, &dhcprenew));
+                      dhcprenew.tv_sec  += g_ds.lease_time / 2;
+                    }
+#if defined(USE_DHCP_FALLBACK)
+                  else if (ret == -EAGAIN)
+                    {
+                      if ((g_netconf.proto & BOOTPROTO_FALLBACK) ==
+                          BOOTPROTO_FALLBACK &&
+                          ++dhcp_fail_count > CONFIG_NETINIT_DHCP_FALLBACK)
+                        {
+                          struct in_addr addr;
+                          g_netconf.proto &= ~IPv4PROTO_DHCP;
+                          addr.s_addr = HTONL(g_netconf.ipaddr);
+                          netlib_set_ipv4addr(NET_DEVNAME, &addr);
+                        }
+                    }
+#endif
+                }
+
+#endif
               reltime.tv_sec  = LONG_TIME_SEC;
               reltime.tv_nsec = 0;
             }
@@ -748,6 +983,13 @@ static int netinit_monitor(void)
                 }
             }
 
+#ifdef CONFIG_NETINIT_DHCPC
+          /* Link went down, next up could be a different network,
+           * so force a renew, on the next up.
+           */
+
+          dhcprenew.tv_sec = 0;
+#endif
           /* In either case, wait for the short, configurable delay */
 
           reltime.tv_sec  = CONFIG_NETINIT_RETRYMSEC / 1000;
@@ -776,11 +1018,13 @@ static int netinit_monitor(void)
   /* TODO: Stop the PHY notifications and remove the signal handler. */
 
 errout_with_notification:
+#if !defined(CONFIG_ARCH_PHY_POLLED)
   ifr.ifr_mii_notify_event.sigev_notify = SIGEV_NONE;
   ioctl(sd, SIOCMIINOTIFY, (unsigned long)&ifr);
 errout_with_sigaction:
   sigaction(CONFIG_NETINIT_SIGNO, &oact, NULL);
 errout_with_socket:
+#endif
   close(sd);
 errout:
   nerr("ERROR: Aborting\n");


### PR DESCRIPTION
I had this PR and it predecessor in upstream. The predecessor was rejected based on using a Board IOCTL. I refactored the PR to use the ipcfg the @patacongo graciously added to rectify call out to the board to get the param from the PX4 parameter system. 
Unfortunately this means we have to re partition the FRAM or store the net config on a different memory. 

I have closed the upstream PR as the ROI has become 0. It is not worth the cost,


## Summary

 ### netinit:Network Monitor add a polled option
 
  Not all boards have in interrupt line from the phy to the Soc. This allows the phy to be polled for link status.
   This may not work on all MAC/PHY combination that have mutually exclusive link management and operating
   modes. The STM32F7 and LAN8742AI do not have such a limitation.

   To use this option the arch must supply CONFIG_ARCH_PHY_POLLED  and not CONFIG_ARCH_PHY_INTERRUPT.

 If the network is not connected the phy init may time out and netinit_net_bringup will return with out completing DHCP or initializing the ntp client.

This change uses the lack of the DHCP lease, to contiune the netinit_net_bringup, once the interface does come up. It also will renew the lease over time, and will re run the dhcp request after a network down/up transition.

###  netinit Net monitior support getting address from fsutils/ipcfg

Uses new fsutils/ipcfg to read the networks settings. 

 ###  netinit:Net monitior support fallback to static IP

   After CONFIG_NETINIT_FALLBACK dhcp attempts, fall back to  the static IP provided by the board via fsutils/ipcfg

## Impact

None All options have Kconfig knobs to turn them off by default

## Testing

FMUV5X with a test vector of all the new Kconfig options

