### PR TITLE
[BACKPORT] apps: canutils: libcanutils: move error.h from NuttX

### DIFF
--- a/canutils/libcanutils/lib.c
+++ b/canutils/libcanutils/lib.c
@@ -48,7 +48,6 @@
 
 #include <sys/socket.h> /* for sa_family_t */
 #include <nuttx/can.h>
-#include <nuttx/can/error.h>
 #include <netpacket/can.h>
 
 #include "lib.h"


### PR DESCRIPTION
Minor backport (migration of can/error.h from NuttX to NuttX-Apps) that will be required by https://github.com/volansi/NuttX/commits/pr-backport-all-can-changes
