### PR TITLE
nsh: return out of memory error if nsh_newconsole returns NULL

### DIFF
--- a/nshlib/nsh_consolemain.c
+++ b/nshlib/nsh_consolemain.c
@@ -70,6 +70,10 @@ int nsh_consolemain(int argc, FAR char *argv[])
   int ret;
 
   DEBUGASSERT(pstate != NULL);
+  if (pstate == NULL)
+    {
+      return -ENOMEM;
+    }
 
 #ifdef CONFIG_NSH_USBDEV_TRACE
   /* Initialize any USB tracing options that were requested */


### PR DESCRIPTION
## Summary

Backport of https://github.com/apache/nuttx-apps/pull/2011.